### PR TITLE
_removeWheelListener no longer leaks the callback into global scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,8 @@
 
   function _removeWheelListener( elem, eventName, callback, useCapture ) {
 
+    var cb;
+
     if (support === "wheel") {
       cb = callback;
     } else {


### PR DESCRIPTION
See #1 for details.

This PR fixes the global scope pollution by declaring the `cb` variable within the _removeWheelListener scope.
